### PR TITLE
add unit test for GitLabClient.getGitLabProjects

### DIFF
--- a/src/main/java/org/dependencytrack/integrations/gitlab/GitLabClient.java
+++ b/src/main/java/org/dependencytrack/integrations/gitlab/GitLabClient.java
@@ -55,6 +55,7 @@ public class GitLabClient {
 
     private final String accessToken;
     private final URI baseURL;
+    private final Config config;
 
     private final Map<GitLabRole, List<Permissions>> rolePermissions = Map.of(
             GitLabRole.GUEST, List.of(
@@ -109,8 +110,13 @@ public class GitLabClient {
                     Permissions.TAG_MANAGEMENT_DELETE));
 
     public GitLabClient(final String accessToken) {
+        this(accessToken, Config.getInstance());
+    }
+
+    public GitLabClient(final String accessToken, final Config config) {
+        this.config = config;
         this.accessToken = accessToken;
-        this.baseURL = URI.create(Config.getInstance().getProperty(Config.AlpineKey.OIDC_ISSUER));;
+        this.baseURL = URI.create(config.getProperty(Config.AlpineKey.OIDC_ISSUER));
     }
 
     public List<GitLabProject> getGitLabProjects() throws IOException, URISyntaxException {

--- a/src/test/java/org/dependencytrack/integrations/gitlab/GitLabClientTest.java
+++ b/src/test/java/org/dependencytrack/integrations/gitlab/GitLabClientTest.java
@@ -1,0 +1,88 @@
+package org.dependencytrack.integrations.gitlab;
+
+import alpine.Config;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.http.HttpHeaders;
+import org.dependencytrack.event.kafka.KafkaProducerInitializer;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.testcontainers.shaded.org.apache.commons.io.IOUtils.resourceToString;
+
+public class GitLabClientTest {
+
+        @BeforeClass
+        public static void beforeClass() {
+                Config.enableUnitTests();
+        }
+
+        @AfterClass
+        public static void after() {
+                KafkaProducerInitializer.tearDown();
+        }
+
+        @Rule
+        public WireMockRule wireMockRule = new WireMockRule();
+
+        @Test
+        public void testGetGitLabProjects() throws URISyntaxException, IOException {
+                String accessToken = "TEST_ACCESS_TOKEN";
+
+                String page1Result = resourceToString("/unit/gitlab-api-getgitlabprojects-response-page-1.json",
+                                StandardCharsets.UTF_8);
+                String page2Result = resourceToString("/unit/gitlab-api-getgitlabprojects-response-page-2.json",
+                                StandardCharsets.UTF_8);
+
+                WireMock.stubFor(WireMock.post("/api/graphql")
+                                .inScenario("test-get-gitlab-projects")
+                                .whenScenarioStateIs(Scenario.STARTED)
+                                .willReturn(WireMock.ok().withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+                                                .withBody(page1Result))
+                                .willSetStateTo("second-page"));
+
+                WireMock.stubFor(WireMock.post("/api/graphql")
+                                .inScenario("test-get-gitlab-projects")
+                                .whenScenarioStateIs("second-page")
+                                .willReturn(WireMock.ok().withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+                                                .withBody(page2Result))
+                                .willSetStateTo("Finished"));
+
+                final var configMock = mock(Config.class);
+
+                when(configMock.getProperty(eq(Config.AlpineKey.OIDC_ISSUER))).thenReturn(wireMockRule.baseUrl());
+
+                GitLabClient gitLabClient = new GitLabClient(accessToken, configMock);
+
+                List<GitLabProject> gitLabProjects = gitLabClient.getGitLabProjects();
+
+                List<String> actualProjectPaths = new ArrayList<String>();
+                for (GitLabProject project : gitLabProjects) {
+                        actualProjectPaths.add(project.getFullPath());
+                }
+
+                List<String> expectedProjectPaths = Arrays.asList(
+                                "test-group/test-subgroup/test-project-1",
+                                "test-group/test-subgroup/test-project-2",
+                                "test-group/test-subgroup-2/test-project-3",
+                                "test-group/test-subgroup-2/test-project-4");
+
+                Assert.assertEquals(actualProjectPaths, expectedProjectPaths);
+        }
+}

--- a/src/test/resources/unit/gitlab-api-getgitlabprojects-response-page-1.json
+++ b/src/test/resources/unit/gitlab-api-getgitlabprojects-response-page-1.json
@@ -1,0 +1,33 @@
+{
+  "data": {
+    "projects": {
+      "nodes": [
+        {
+          "name": "test-project-1",
+          "fullPath": "test-group/test-subgroup/test-project-1",
+          "maxAccessLevel": {
+            "stringValue": "DEVELOPER"
+          }
+        },
+        {
+          "name": "test-project-2",
+          "fullPath": "test-group/test-subgroup/test-project-2",
+          "maxAccessLevel": {
+            "stringValue": "REPORTER"
+          }
+        },
+        {
+          "name": "test-project-3",
+          "fullPath": "test-group/test-subgroup-2/test-project-3",
+          "maxAccessLevel": {
+            "stringValue": "REPORTER"
+          }
+        }
+      ],
+      "pageInfo": {
+        "endCursor": "eyJpZCI6IjE1ODU5NyJ9",
+        "hasNextPage": true
+      }
+    }
+  }
+}

--- a/src/test/resources/unit/gitlab-api-getgitlabprojects-response-page-2.json
+++ b/src/test/resources/unit/gitlab-api-getgitlabprojects-response-page-2.json
@@ -1,0 +1,19 @@
+{
+  "data": {
+    "projects": {
+      "nodes": [
+        {
+          "name": "test-project-4",
+          "fullPath": "test-group/test-subgroup-2/test-project-4",
+          "maxAccessLevel": {
+            "stringValue": "DEVELOPER"
+          }
+        },
+      ],
+      "pageInfo": {
+        "endCursor": "zzzzzzzzzzzzzzzzzzzz",
+        "hasNextPage": false
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Description

This change adds a unit test for the `GitLabClient.getGitLabProjects` method.

### Addressed Issue

API Server Unit Tests

### Additional Details

The constructor of `GitLabClient` was overloaded to allow dependency injection by specifying a `Config`, to be able to mock the value of the `alpine.oidc.issuer` property.


### Checklist

- [x] I have read and understand the [contributing guidelines]
- [x] This PR just adds unit tests

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
